### PR TITLE
🐛 Filter out None documents

### DIFF
--- a/src/kapply_core/deploy.py
+++ b/src/kapply_core/deploy.py
@@ -72,6 +72,16 @@ def deploy_release(release_name, release_namespace, resources):
         previous_signature
     )
     previous_resources = load_resources(previous_revision)
+
+    resources = filter(
+        lambda rsrc: rsrc is not None,
+        resources
+    )
+    previous_resources = filter(
+        lambda rsrc: rsrc is not None,
+        previous_resources
+    )
+
     deleted_resources = get_deleted_resources(previous_resources, resources)
     apply_resources(resources)
     delete_resources(deleted_resources)

--- a/src/kapply_core/resources.py
+++ b/src/kapply_core/resources.py
@@ -75,8 +75,7 @@ def apply_resource(resource):
 
 def apply_resources(resources):
     for resource in resources:
-        if resource:
-            apply_resource(resource)
+        apply_resource(resource)
 
 
 def delete_resource(resource):
@@ -107,5 +106,4 @@ def delete_resource(resource):
 
 def delete_resources(resources):
     for resource in resources:
-        if resource:
-            delete_resource(resource)
+        delete_resource(resource)


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: Filter out `None` resources to not process them